### PR TITLE
Bug fix: exceptions should not be be swallowed during polling 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=1.1.0
+version=2.0.0
 groupId=com.nike
 artifactId=cerberus-archaius-client
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=1.0.0
+version=1.1.0
 groupId=com.nike
 artifactId=cerberus-archaius-client
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,11 @@ repositories {
 
 dependencies {
     compile 'com.netflix.archaius:archaius-aws:0.6.5'
-    compile 'com.nike:cerberus-client:1.0.0'
+    compile 'com.nike:cerberus-client:1.2.0'
+
+    compile "org.apache.commons:commons-lang3:3.5"
+    compile "com.squareup.okhttp3:okhttp:3.3.1"
+
     compile 'org.slf4j:slf4j-api:1.7.14'
     compile 'org.slf4j:slf4j-simple:1.7.14'
 

--- a/src/main/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSource.java
+++ b/src/main/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSource.java
@@ -62,16 +62,12 @@ public class CerberusConfigurationSource extends BaseCerberusConfigurationSource
      */
     @Override
     public PollResult poll(final boolean initial, final Object checkPoint) {
-
         final Map<String, Object> config = Maps.newHashMap();
         for (final String path : getPaths()) {
-            try {
-                final VaultResponse vaultResponse = getVaultClient().read(path);
-                config.putAll(vaultResponse.getData());
-            } catch (Exception e) {
-                logger.error("Exception loading properties from Cerberus, will not process changes from path "+path, e);
-            }
+            final VaultResponse vaultResponse = getVaultClient().read(path);
+            config.putAll(vaultResponse.getData());
         }
         return PollResult.createFull(config);
     }
+
 }

--- a/src/main/java/com/nike/cerberus/archaius/client/provider/NamespacedCerberusConfigurationSource.java
+++ b/src/main/java/com/nike/cerberus/archaius/client/provider/NamespacedCerberusConfigurationSource.java
@@ -115,22 +115,18 @@ public class NamespacedCerberusConfigurationSource extends BaseCerberusConfigura
      */
     private Map<String, Object> buildEntriesMap(final String path) {
         final Map<String, Object> config = Maps.newHashMap();
-        try {
-            if (isFolder(path)) {
-                final VaultListResponse listResponse = getVaultClient().list(path);
-                for(final String subpath : listResponse.getKeys()) {
-                    final String fullPath = path + subpath;
-                    config.putAll(buildEntriesMap(fullPath));
-                }
-            } else {
-                final VaultResponse vaultResponse = getVaultClient().read(path);
-                final Map<String, String> dataFromVault = vaultResponse.getData();
-                for (final Map.Entry<String, String> pair : dataFromVault.entrySet()) {
-                    config.put(getPathPrefix(path) + pair.getKey(), pair.getValue());
-                }
+        if (isFolder(path)) {
+            final VaultListResponse listResponse = getVaultClient().list(path);
+            for(final String subpath : listResponse.getKeys()) {
+                final String fullPath = path + subpath;
+                config.putAll(buildEntriesMap(fullPath));
             }
-        } catch (final Exception e) {
-            logger.error("Exception loading properties from Cerberus, will not process changes from path, " + path, e);
+        } else {
+            final VaultResponse vaultResponse = getVaultClient().read(path);
+            final Map<String, String> dataFromVault = vaultResponse.getData();
+            for (final Map.Entry<String, String> pair : dataFromVault.entrySet()) {
+                config.put(getPathPrefix(path) + pair.getKey(), pair.getValue());
+            }
         }
         return config;
     }

--- a/src/test/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSourceTest.java
+++ b/src/test/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSourceTest.java
@@ -18,6 +18,7 @@ package com.nike.cerberus.archaius.client.provider;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.netflix.config.PollResult;
 import com.nike.vault.client.VaultClient;
 import com.nike.vault.client.VaultServerException;
@@ -26,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -95,6 +97,21 @@ public class CerberusConfigurationSourceTest {
 
         // call the method under test
         subject.poll(true, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_constructor_validation_vault_client_cannot_be_null() {
+        new CerberusConfigurationSource(null, Sets.newHashSet("/fake/path"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_constructor_validation_paths_cannot_be_null() {
+        new CerberusConfigurationSource(vaultClient, (Set<String>)null );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_constructor_validation_paths_cannot_be_empty() {
+        new CerberusConfigurationSource(vaultClient, Sets.<String>newHashSet());
     }
 
 }

--- a/src/test/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSourceTest.java
+++ b/src/test/java/com/nike/cerberus/archaius/client/provider/CerberusConfigurationSourceTest.java
@@ -83,7 +83,7 @@ public class CerberusConfigurationSourceTest {
 
     }
 
-    @Test
+    @Test(expected = VaultServerException.class)
     public void poll_only_loads_data_for_path1() {
         // mock dependencies
         final Map<String, String> foobinatorMap = Maps.newHashMap();
@@ -94,13 +94,7 @@ public class CerberusConfigurationSourceTest {
         when(vaultClient.read(PATH_2)).thenThrow(new VaultServerException(500, Lists.newArrayList("Internal error.")));
 
         // call the method under test
-        PollResult result = subject.poll(true, null);
-
-        // verify results
-        assertThat(result).isNotNull();
-        assertThat(result.getComplete()).isNotNull();
-        assertThat(result.getComplete()).containsOnlyKeys(FOOBINATOR_CONFIG_KEY);
-
+        subject.poll(true, null);
     }
 
 }

--- a/src/test/java/com/nike/cerberus/archaius/client/provider/NamespacedCerberusConfigurationSourceTest.java
+++ b/src/test/java/com/nike/cerberus/archaius/client/provider/NamespacedCerberusConfigurationSourceTest.java
@@ -100,7 +100,7 @@ public class NamespacedCerberusConfigurationSourceTest {
         assertThat(result.getComplete()).containsOnlyKeys(FOOBINATOR_CONFIG_NAMESPACED_KEY, ARTEMIS_CONFIG_NAMESPACED_KEY);
     }
 
-    @Test
+    @Test(expected = VaultServerException.class)
     public void poll_fails_to_read_path1_but_is_successful_on_path2() {
         // mock dependencies to ensure an error
         final VaultListResponse path1ListResponse = new VaultListResponse()
@@ -122,10 +122,5 @@ public class NamespacedCerberusConfigurationSourceTest {
 
         // call the method under test
         PollResult result = subject.poll(true, null);
-
-        // verify results
-        assertThat(result).isNotNull();
-        assertThat(result.getComplete()).isNotNull();
-        assertThat(result.getComplete()).containsOnlyKeys(ARTEMIS_CONFIG_NAMESPACED_KEY);
     }
 }


### PR DESCRIPTION
This bug when combined with 'ignoreDeletesFromSource=false' flag result in local copies of keys being deleted if Cerberus was unreachable.  The downside of this change is if the client is given a mixture of good and invalid paths in Cerberus, it won't work, but that does seem like the correct behavior.

Using latest cerberus-client version