### PR TITLE
Upgrading Cerberus java-client dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=2.3.0
+version=3.0.0
 groupId=com.nike
 artifactId=cerberus-archaius-client
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile 'com.netflix.archaius:archaius-aws:0.6.5'
-    compile 'com.nike:cerberus-client:1.4.1'
+    compile 'com.nike:cerberus-client:2.0.1'
 
     compile "org.apache.commons:commons-lang3:3.5"
     compile "com.squareup.okhttp3:okhttp:3.6.0"


### PR DESCRIPTION
Upgrading Cerberus java-client dependency to take advantage of:

- Bug fix: expiration date for credentials was not being set correctly.
- The new Cerberus Management Service 'v2/auth/iam-principal' API

Note: This release is not compatible with versions of CMS older than v0.17.0