### PR TITLE
Use shadowed HttpUrl in test

### DIFF
--- a/src/test/java/com/nike/cerberus/archaius/client/ArchaiusCerberusClientFactoryTest.java
+++ b/src/test/java/com/nike/cerberus/archaius/client/ArchaiusCerberusClientFactoryTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.nike.cerberus.client.CerberusClient;
 import com.nike.cerberus.client.CerberusClientException;
-import okhttp3.HttpUrl;
+import cerberus.okhttp3.HttpUrl;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/nike/cerberus/archaius/client/ArchaiusCerberusClientFactoryTest.java
+++ b/src/test/java/com/nike/cerberus/archaius/client/ArchaiusCerberusClientFactoryTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import cerberus.okhttp3.HttpUrl;
 import com.nike.cerberus.client.CerberusClient;
 import com.nike.cerberus.client.CerberusClientException;
-import cerberus.okhttp3.HttpUrl;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
The test for the client factory needed to be updated to use the shadowed version of okhttp3.